### PR TITLE
Update findEventHandlers.js

### DIFF
--- a/findEventHandlers.js
+++ b/findEventHandlers.js
@@ -1,5 +1,6 @@
 ﻿var findEventHandlers = function (eventType, jqSelector) {
     var results = [];
+    var $ = jQuery;// to avoid conflict between others frameworks like Mootools
 
     var arrayIntersection = function (array1, array2) {
         return $(array1).filter(function (index, element) {


### PR DESCRIPTION
To avoid conflict between others frameworks like Mootools.
Example: $ is used with Mootools and jQuery is used with a noConflict().
Using var $ = jQuery; will not interfer the framework used in $ outside the function findEventHandlers
