### PR TITLE
Added support to view all events attached to the element.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,16 @@ findHandlersJS
 
 Stop wasting your time looking for where those handlers are registered, use findHandlersJS and discover them instantly.
 
-Usage: findEventHandlers(eventType, jQuerySelector)
+Usage: `findEventHandlers(eventType, jQuerySelector)`
 
 Imagine you want to find all the "click" event handlers for all the buttons that are immediate children of the div with id="myDiv":
 
-findEventHandlers("click", "div#myDiv > :button")
+`findEventHandlers("click", "div#myDiv > :button")`
 
-It will return an array with the element names, the jQuery $._data event information and the list of elements that that event handler covers (targets).
+It will return an array with the element names, the `jQuery $._data` event information and the list of elements that that event handler covers (targets).
 
-For example, if div#myDiv has a delegate handler with the selector :button and there is a button with id="save" inside the div, you would get this result:
+For example, if `div#myDiv` has a delegate handler with the selector `:button` and there is a button with `id="save"` inside the div, you would get this result:
+```
 [{
 	element: div#myDiv,
 	events: [{
@@ -22,7 +23,12 @@ For example, if div#myDiv has a delegate handler with the selector :button and t
 		...
 		targets: [button#save]			
 	}]
-}] 
+}]
+```
+
+If you want to find any available events attached to the element, send "*" as first argument.
+
+`findEventHandlers("*", "div#myDiv > :button")`
 
 If you are using the console on Chrome, you can right click the handler, click show function definition and add  breakpoints to debug the handlers.
 

--- a/findEventHandlers.js
+++ b/findEventHandlers.js
@@ -41,23 +41,35 @@
         $elementsToWatch = $elementsToWatch.add(document); 
     var $allElements = $("*").add(document);
 
-    $.each($allElements, function (elementIndex, element) {
-        var allElementEvents = $._data(element, "events");
-        if (allElementEvents !== void 0 && allElementEvents[eventType] !== void 0) {
-            var eventContainer = allElementEvents[eventType];
-            $.each(eventContainer, function(eventIndex, event){
-                var isDelegateEvent = event.selector !== void 0 && event.selector !== null;
-                var $elementsCovered;
-                if (isDelegateEvent) {
-                    $elementsCovered = $(event.selector, element); //only look at children of the element, since those are the only ones the handler covers
-                } else {
-                    $elementsCovered = $(element); //just itself
-                }
-                if (haveCommonElements($elementsCovered, $elementsToWatch)) {
-                    addEventHandlerInfo(element, event, $elementsCovered);
-                }
-            });
-        }
+    if(eventType == "*"){
+        allEventTypes = [
+            "click", "dblclick", "hover", "mousedown", "mouseenter", "mouseleave", "mousemove", "mouseout", "mouseover", "mouseup", "toggle", //mouse events
+            "keydown", "keypress", "keyup", //keyboard events
+            "blur", "change", "focus", "focusin", "focusout", "select", "submit", //form events
+            "error", "load", "ready", "resize", "scroll", "unload" //document/window events
+        ];
+    }
+    else allEventTypes = [eventType];
+    
+    $.each(allEventTypes, function(eventIndex, eventType){
+        $.each($allElements, function (elementIndex, element) {
+            var allElementEvents = $._data(element, "events");
+            if (allElementEvents !== void 0 && allElementEvents[eventType] !== void 0) {
+                var eventContainer = allElementEvents[eventType];
+                $.each(eventContainer, function(eventIndex, event){
+                    var isDelegateEvent = event.selector !== void 0 && event.selector !== null;
+                    var $elementsCovered;
+                    if (isDelegateEvent) {
+                        $elementsCovered = $(event.selector, element); //only look at children of the element, since those are the only ones the handler covers
+                    } else {
+                        $elementsCovered = $(element); //just itself
+                    }
+                    if (haveCommonElements($elementsCovered, $elementsToWatch)) {
+                        addEventHandlerInfo(element, event, $elementsCovered);
+                    }
+                });
+            }
+        });
     });
 
     return results;


### PR DESCRIPTION
An element can have many events attached to it. Instead of checking all events one by one, now user can just send "*" as event name in first parameter to view all events for that element.